### PR TITLE
fix: migrate multiple component classes

### DIFF
--- a/packages/cli/src/angular/migrations/standalone/0002-import-standalone-component.ts
+++ b/packages/cli/src/angular/migrations/standalone/0002-import-standalone-component.ts
@@ -55,7 +55,7 @@ export const migrateComponents = async (
             cliOptions,
           );
 
-          return await saveFileChanges(tsSourceFile, cliOptions);
+          await saveFileChanges(tsSourceFile, cliOptions);
         }
       }
     } else if (sourceFile.getFilePath().endsWith(".ts")) {
@@ -76,7 +76,7 @@ export const migrateComponents = async (
         );
 
         if (ionicComponents.length > 0 || ionIcons.length > 0) {
-          return await saveFileChanges(sourceFile, cliOptions);
+          await saveFileChanges(sourceFile, cliOptions);
         }
       }
     }


### PR DESCRIPTION
Resolves #5 

The codemod was returning once the first component that matched the criteria was migrated, instead of migrating all the available components/files. 

This was an oversight when refactoring and adding testing, where originally I was testing the returned result of the codemod function instead of looking at the source file contents after the migration. 