### PR TITLE
fix: remove duplicate imports when migrating standalone components

### DIFF
--- a/apps/angular/ionic-angular-modules/package.json
+++ b/apps/angular/ionic-angular-modules/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^16.0.0",
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
-    "@ionic/angular": "^7.0.0",
+    "@ionic/angular": "^7.5.0",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/apps/angular/ionic-angular-standalone/package.json
+++ b/apps/angular/ionic-angular-standalone/package.json
@@ -26,7 +26,7 @@
     "@capacitor/haptics": "5.0.6",
     "@capacitor/keyboard": "5.0.6",
     "@capacitor/status-bar": "5.0.6",
-    "@ionic/angular": "^7.0.0",
+    "@ionic/angular": "^7.5.0",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/apps/angular/ionic-angular-standalone/src/app/view-child/view-child.page.html
+++ b/apps/angular/ionic-angular-standalone/src/app/view-child/view-child.page.html
@@ -1,0 +1,13 @@
+<ion-header [translucent]="true">
+  <ion-toolbar>
+    <ion-title>view-child</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content [fullscreen]="true">
+  <ion-header collapse="condense">
+    <ion-toolbar>
+      <ion-title size="large">view-child</ion-title>
+    </ion-toolbar>
+  </ion-header>
+</ion-content>

--- a/apps/angular/ionic-angular-standalone/src/app/view-child/view-child.page.ts
+++ b/apps/angular/ionic-angular-standalone/src/app/view-child/view-child.page.ts
@@ -7,7 +7,7 @@ import { IonContent, IonicModule } from '@ionic/angular';
   selector: 'app-view-child',
   templateUrl: './view-child.page.html',
   standalone: true,
-  imports: [IonicModule, CommonModule, FormsModule]
+  imports: [IonicModule, CommonModule, FormsModule],
 })
 export class ViewChildPage implements OnInit {
   /**
@@ -16,7 +16,7 @@ export class ViewChildPage implements OnInit {
   @ViewChild(IonContent)
   content!: IonContent;
 
-  constructor() { }
+  constructor() {}
 
-  ngOnInit() { }
+  ngOnInit() {}
 }

--- a/apps/angular/ionic-angular-standalone/src/app/view-child/view-child.page.ts
+++ b/apps/angular/ionic-angular-standalone/src/app/view-child/view-child.page.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonContent, IonicModule } from '@ionic/angular';
+
+@Component({
+  selector: 'app-view-child',
+  templateUrl: './view-child.page.html',
+  standalone: true,
+  imports: [IonicModule, CommonModule, FormsModule]
+})
+export class ViewChildPage implements OnInit {
+  /**
+   * Referencing the template's ion-content results in a double call.
+   */
+  @ViewChild(IonContent)
+  content!: IonContent;
+
+  constructor() { }
+
+  ngOnInit() { }
+}

--- a/packages/cli/src/angular/migrations/standalone/0002-import-standalone-component.ts
+++ b/packages/cli/src/angular/migrations/standalone/0002-import-standalone-component.ts
@@ -154,6 +154,12 @@ async function migrateAngularComponentClass(
         componentClassName,
         "@ionic/angular/standalone",
       );
+      /**
+       * This removes the import from the class, if it is present.
+       * An example where it may exist is when the developer has
+       * a @ViewChild decorator that references an ionic component.
+       */
+      removeImportFromClass(sourceFile, componentClassName, "@ionic/angular");
     } else if (ngModuleSourceFile) {
       const componentClassName = kebabCaseToPascalCase(ionicComponent);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^16.0.0
         version: 16.0.0(@angular/common@16.0.0)(@angular/core@16.0.0)(@angular/platform-browser@16.0.0)(rxjs@7.8.1)
       '@ionic/angular':
-        specifier: ^7.0.0
-        version: 7.0.0(@angular/core@16.0.0)(@angular/forms@16.0.0)(@angular/router@16.0.0)(rxjs@7.8.1)(zone.js@0.13.0)
+        specifier: ^7.5.0
+        version: 7.5.0(@angular/core@16.0.0)(@angular/forms@16.0.0)(@angular/router@16.0.0)(rxjs@7.8.1)(zone.js@0.13.0)
       ionicons:
         specifier: ^7.0.0
         version: 7.0.0
@@ -139,8 +139,8 @@ importers:
         specifier: 5.0.6
         version: 5.0.6(@capacitor/core@5.4.0)
       '@ionic/angular':
-        specifier: ^7.0.0
-        version: 7.0.0(@angular/core@16.0.0)(@angular/forms@16.0.0)(@angular/router@16.0.0)(rxjs@7.8.1)(zone.js@0.13.0)
+        specifier: ^7.5.0
+        version: 7.5.0(@angular/core@16.0.0)(@angular/forms@16.0.0)(@angular/router@16.0.0)(rxjs@7.8.1)(zone.js@0.13.0)
       ionicons:
         specifier: ^7.0.0
         version: 7.0.0
@@ -2791,8 +2791,8 @@ packages:
       - chokidar
     dev: true
 
-  /@ionic/angular@7.0.0(@angular/core@16.0.0)(@angular/forms@16.0.0)(@angular/router@16.0.0)(rxjs@7.8.1)(zone.js@0.13.0):
-    resolution: {integrity: sha512-vsSOPoWyO8Wl2EcUG9VJN50HsLG5B08q2mz/D6WAWeG0VlFGS2OdjtBOsFT3UKWuznuACxnTPNdUCk9JtFCgRw==}
+  /@ionic/angular@7.5.0(@angular/core@16.0.0)(@angular/forms@16.0.0)(@angular/router@16.0.0)(rxjs@7.8.1)(zone.js@0.13.0):
+    resolution: {integrity: sha512-0eZB/2/4ArfBt6YcYDF8VwfK0J8VRmywpbzlmsQXrubOAqd+Xaq2yYfLmzRfyrdKBhg7TyA+L6MyJ6w0Y7fbXA==}
     peerDependencies:
       '@angular/core': '>=14.0.0'
       '@angular/forms': '>=14.0.0'
@@ -2803,7 +2803,7 @@ packages:
       '@angular/core': 16.0.0(rxjs@7.8.1)(zone.js@0.13.0)
       '@angular/forms': 16.0.0(@angular/common@16.0.0)(@angular/core@16.0.0)(@angular/platform-browser@16.0.0)(rxjs@7.8.1)
       '@angular/router': 16.0.0(@angular/common@16.0.0)(@angular/core@16.0.0)(@angular/platform-browser@16.0.0)(rxjs@7.8.1)
-      '@ionic/core': 7.0.0
+      '@ionic/core': 7.5.0
       ionicons: 7.1.2
       jsonc-parser: 3.2.0
       rxjs: 7.8.1
@@ -2822,11 +2822,11 @@ packages:
       - supports-color
     dev: true
 
-  /@ionic/core@7.0.0:
-    resolution: {integrity: sha512-pM8qOaea9ZbqZbGnoIswaeeTiHJKNQ9ziSNHSILDpdd4FjpxZjOeMgNUdvYzh5rX9fA6hEM2wodg7McIWHgvZQ==}
+  /@ionic/core@7.5.0:
+    resolution: {integrity: sha512-oreRvbKj8VqqO9JraxR/n56GC6MHQtnJEmZf/EFuw5ZvDV8My91uNIzLkb4P9SvPL5NRr/Z0TFem28cgRf5YVA==}
     dependencies:
-      '@stencil/core': 3.4.2
-      ionicons: 7.1.2
+      '@stencil/core': 4.4.1
+      ionicons: 7.2.1
       tslib: 2.5.0
     dev: false
 
@@ -3323,9 +3323,9 @@ packages:
     hasBin: true
     dev: false
 
-  /@stencil/core@3.4.2:
-    resolution: {integrity: sha512-FAUhUVaakCy29nU2GwO/HQBRV1ihPRvncz3PUc8oR+UJLAxGabTmP8PLY7wvHfbw+Cvi4VXfJFTBvdfDu6iKPQ==}
-    engines: {node: '>=14.10.0', npm: '>=6.0.0'}
+  /@stencil/core@4.4.1:
+    resolution: {integrity: sha512-SirGcrb5yKHCn2BwdM7HGVXuvCdmwiXlVczEj8jJxQIm42CAUQCUECxtZidTzp+oZBZnWLnoAvfanchJsgkQzA==}
+    engines: {node: '>=16.0.0', npm: '>=7.10.0'}
     hasBin: true
     dev: false
 
@@ -7384,6 +7384,12 @@ packages:
     resolution: {integrity: sha512-zZ4njAqSP39H8RRvZhJvkHsv7cBjYE/VfInH218Osf2UVxJITSOutTTd25MW+tAXKN5fheYzclUXUsF55JHUDg==}
     dependencies:
       '@stencil/core': 2.22.3
+    dev: false
+
+  /ionicons@7.2.1:
+    resolution: {integrity: sha512-2pvCM7DGVEtbbj48PJzQrCADCQrqjU1nUYX9l9PyEWz3ZfdnLdAouqwPxLdl8tbaF9cE7OZRSlyQD7oLOLnGoQ==}
+    dependencies:
+      '@stencil/core': 4.4.1
     dev: false
 
   /ip@2.0.0:


### PR DESCRIPTION
This PR resolves an issue where existing imports to components would be persisted when migrating a standalone component, resulting in duplicate import statements after the migration.

e.g.:
```ts
import { IonContent } from "@ionic/angular";

@Component({
  template: `<ion-content></ion-content>`
  standalone: true
})
export class MyComponent {
  @ViewChild(IonContent) content!: IonContent;
}
```

Resulted in:
```ts
import { IonContent } from "@ionic/angular/standalone";
import { IonContent } from "@ionic/angular/standalone";

@Component({
  template: `<ion-content></ion-content>`
  standalone: true,
  imports: [IonContent]
})
export class MyComponent {
  @ViewChild(IonContent) content!: IonContent;
}
```

This work is split from the reproductions provided in #13