### PR TITLE
fix: migrate ion-skeleton components to standalone imports

### DIFF
--- a/packages/cli/src/angular/utils/ionic-utils.ts
+++ b/packages/cli/src/angular/utils/ionic-utils.ts
@@ -75,7 +75,7 @@ export const IONIC_COMPONENTS = [
   "ion-segment-button",
   "ion-select",
   "ion-select-option",
-  "ion-skeleton",
+  "ion-skeleton-text",
   "ion-spinner",
   "ion-split-pane",
   "ion-tab",


### PR DESCRIPTION
I noticed that skeleton-text components are not updated.

https://ionicframework.com/docs/ja/api/skeleton-text