### PR TITLE
fix: migrate ion-row components to standalone imports

### DIFF
--- a/packages/cli/src/angular/utils/ionic-utils.ts
+++ b/packages/cli/src/angular/utils/ionic-utils.ts
@@ -70,6 +70,7 @@ export const IONIC_COMPONENTS = [
   "ion-router-outlet",
   "ion-route",
   "ion-route-redirect",
+  "ion-row",
   "ion-searchbar",
   "ion-segment",
   "ion-segment-button",


### PR DESCRIPTION
I noticed this is also missing.