### PR TITLE
fix: providers order does not impact bootstrapApplication migration

### DIFF
--- a/packages/cli/src/angular/migrations/standalone/0003-migrate-bootstrap-application.ts
+++ b/packages/cli/src/angular/migrations/standalone/0003-migrate-bootstrap-application.ts
@@ -68,9 +68,17 @@ export const migrateBootstrapApplication = async (
       return;
     }
 
-    const importProvidersFromFunctionCall = providersArray.getFirstChildByKind(
-      SyntaxKind.CallExpression,
-    );
+    const importProvidersFromFunctionCall = providersArray
+      .getChildrenOfKind(SyntaxKind.CallExpression)
+      .find((callExpression) => {
+        const identifier = callExpression.getFirstChildByKind(
+          SyntaxKind.Identifier,
+        );
+        return (
+          identifier !== undefined &&
+          identifier.getText() === "importProvidersFrom"
+        );
+      });
 
     if (importProvidersFromFunctionCall === undefined) {
       return;


### PR DESCRIPTION
Resolves #24 

The order of identifier expressions in the `providers` array will no longer impact if the migration can successfully migrate `importProvidersFrom` usages. 