### PR TITLE
fix: expected the module specifier to be a string literal

### DIFF
--- a/packages/cli/src/angular/migrations/standalone/0004-migrate-import-statements.ts
+++ b/packages/cli/src/angular/migrations/standalone/0004-migrate-import-statements.ts
@@ -8,42 +8,42 @@ export const migrateImportStatements = async (
   project: Project,
   cliOptions: CliOptions,
 ) => {
-  // Get all typescript source files in the project and update any @ionic/angular imports to @ionic/angular/standalone
-  for (const sourceFile of project.getSourceFiles()) {
-    if (sourceFile.getFilePath().endsWith(".html")) {
-      continue;
-    }
+    // Get all typescript source files in the project and update any @ionic/angular imports to @ionic/angular/standalone
+    for (const sourceFile of project.getSourceFiles()) {
+        if (!sourceFile.getFilePath().endsWith('.ts')) {
+            continue;
+        }
 
-    let hasChanges = false;
+        let hasChanges = false;
 
-    const importDeclarations = sourceFile.getImportDeclarations();
-    importDeclarations.forEach((importDeclaration) => {
-      const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
-      if (moduleSpecifier === "@ionic/angular") {
-        importDeclaration.setModuleSpecifier("@ionic/angular/standalone");
+        const importDeclarations = sourceFile.getImportDeclarations();
+        importDeclarations.forEach((importDeclaration) => {
+            const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
+            if (moduleSpecifier === "@ionic/angular") {
+                importDeclaration.setModuleSpecifier("@ionic/angular/standalone");
 
-        const namedImports = importDeclaration.getNamedImports();
-        const importSpecifier = namedImports.find(
+                const namedImports = importDeclaration.getNamedImports();
+                const importSpecifier = namedImports.find(
           (n) => n.getName() === "IonicModule",
         );
 
-        if (importSpecifier) {
-          if (namedImports.length > 1) {
-            // Remove the IonicModule import specifier.
-            importSpecifier.remove();
-          } else {
-            // If this is the only import specifier, remove the entire import declaration.
-            importDeclaration.remove();
-          }
-          removeImportFromNgModuleDecorator(sourceFile, "IonicModule");
+                if (importSpecifier) {
+                    if (namedImports.length > 1) {
+                        // Remove the IonicModule import specifier.
+                        importSpecifier.remove();
+                    } else {
+                        // If this is the only import specifier, remove the entire import declaration.
+                        importDeclaration.remove();
+                    }
+                    removeImportFromNgModuleDecorator(sourceFile, "IonicModule");
+                }
+
+                hasChanges = true;
+            }
+        });
+
+        if (hasChanges) {
+            await saveFileChanges(sourceFile, cliOptions);
         }
-
-        hasChanges = true;
-      }
-    });
-
-    if (hasChanges) {
-      await saveFileChanges(sourceFile, cliOptions);
     }
-  }
 };

--- a/packages/cli/src/angular/migrations/standalone/0004-migrate-import-statements.ts
+++ b/packages/cli/src/angular/migrations/standalone/0004-migrate-import-statements.ts
@@ -8,42 +8,42 @@ export const migrateImportStatements = async (
   project: Project,
   cliOptions: CliOptions,
 ) => {
-    // Get all typescript source files in the project and update any @ionic/angular imports to @ionic/angular/standalone
-    for (const sourceFile of project.getSourceFiles()) {
-        if (!sourceFile.getFilePath().endsWith('.ts')) {
-            continue;
-        }
+  // Get all typescript source files in the project and update any @ionic/angular imports to @ionic/angular/standalone
+  for (const sourceFile of project.getSourceFiles()) {
+    if (!sourceFile.getFilePath().endsWith(".ts")) {
+      continue;
+    }
 
-        let hasChanges = false;
+    let hasChanges = false;
 
-        const importDeclarations = sourceFile.getImportDeclarations();
-        importDeclarations.forEach((importDeclaration) => {
-            const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
-            if (moduleSpecifier === "@ionic/angular") {
-                importDeclaration.setModuleSpecifier("@ionic/angular/standalone");
+    const importDeclarations = sourceFile.getImportDeclarations();
+    importDeclarations.forEach((importDeclaration) => {
+      const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
+      if (moduleSpecifier === "@ionic/angular") {
+        importDeclaration.setModuleSpecifier("@ionic/angular/standalone");
 
-                const namedImports = importDeclaration.getNamedImports();
-                const importSpecifier = namedImports.find(
+        const namedImports = importDeclaration.getNamedImports();
+        const importSpecifier = namedImports.find(
           (n) => n.getName() === "IonicModule",
         );
 
-                if (importSpecifier) {
-                    if (namedImports.length > 1) {
-                        // Remove the IonicModule import specifier.
-                        importSpecifier.remove();
-                    } else {
-                        // If this is the only import specifier, remove the entire import declaration.
-                        importDeclaration.remove();
-                    }
-                    removeImportFromNgModuleDecorator(sourceFile, "IonicModule");
-                }
-
-                hasChanges = true;
-            }
-        });
-
-        if (hasChanges) {
-            await saveFileChanges(sourceFile, cliOptions);
+        if (importSpecifier) {
+          if (namedImports.length > 1) {
+            // Remove the IonicModule import specifier.
+            importSpecifier.remove();
+          } else {
+            // If this is the only import specifier, remove the entire import declaration.
+            importDeclaration.remove();
+          }
+          removeImportFromNgModuleDecorator(sourceFile, "IonicModule");
         }
+
+        hasChanges = true;
+      }
+    });
+
+    if (hasChanges) {
+      await saveFileChanges(sourceFile, cliOptions);
     }
+  }
 };

--- a/packages/cli/src/angular/migrations/standalone/0004-migrate-import-statements.ts
+++ b/packages/cli/src/angular/migrations/standalone/0004-migrate-import-statements.ts
@@ -10,6 +10,10 @@ export const migrateImportStatements = async (
 ) => {
   // Get all typescript source files in the project and update any @ionic/angular imports to @ionic/angular/standalone
   for (const sourceFile of project.getSourceFiles()) {
+    if (sourceFile.getFilePath().endsWith(".html")) {
+      continue;
+    }
+
     let hasChanges = false;
 
     const importDeclarations = sourceFile.getImportDeclarations();


### PR DESCRIPTION
fixes #32

For some reason `project.getSourceFiles()` was returning html files causing `sourceFile.getImportDeclarations();` to fall over. I've also included printing the stack trace rather than just the error message to give the errors slightly more clarity.