### PR TITLE
fix: migrate root Ionic module without config

### DIFF
--- a/packages/cli/src/angular/migrations/standalone/0003-migrate-bootstrap-application.ts
+++ b/packages/cli/src/angular/migrations/standalone/0003-migrate-bootstrap-application.ts
@@ -129,9 +129,9 @@ export const migrateBootstrapApplication = async (
       const ionicConfigObjectLiteralExpression =
         importProvidersFromFunctionCallIonicModuleForRootCallExpressionArguments[0];
 
-      providersArray.addElement(
-        `provideIonicAngular(${ionicConfigObjectLiteralExpression.getText()})`,
-      );
+      const ionicConfig = ionicConfigObjectLiteralExpression?.getText() ?? "{}";
+
+      providersArray.addElement(`provideIonicAngular(${ionicConfig})`);
 
       // Remove the IonicModule.forRoot from the importProvidersFrom function call.
       importProvidersFromFunctionCall.removeArgument(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -96,9 +96,10 @@ async function main() {
       dir: cli.dir,
       spinner: s,
     });
-  } catch (e: any) {
+  } catch (e) {
     s.stop("An error occurred during the migration.", 1);
-    log.error(e.message);
+    const error = e as Error;
+    log.error(error.stack ?? error.message);
   }
 
   outro(


### PR DESCRIPTION
Resolves #31 

Usages of `IonicModule.forRoot` that did not explicitly have an config argument would fail to migrate. This PR corrects that logic and improves the error handling to provide a stack trace in the future to help with debugging/development of reported issues. 